### PR TITLE
updated moving bed and bubbling fluidized bed unit models and tests t…

### DIFF
--- a/idaes/gas_solid_contactors/unit_models/bubbling_fluidized_bed.py
+++ b/idaes/gas_solid_contactors/unit_models/bubbling_fluidized_bed.py
@@ -1941,9 +1941,14 @@ see reaction package for documentation.}"""))
                             blk.solid_emulsion_rxn_ext_constraint[t, x, r])
                     for j in solid_phase.property_package.component_list:
                         solid_emulsion_rxn_gen[t, x, 'Sol', j].unfix()
-                        calculate_variable_from_constraint(
-                            solid_emulsion_rxn_gen[t, x, 'Sol', j],
-                            solid_emulsion_stoichiometry_eqn[t, x, 'Sol', j])
+                        if not ((blk.config.transformation_scheme != "FORWARD"
+                                 and x == blk.length_domain.first()) or
+                                (blk.config.transformation_scheme == "FORWARD"
+                                 and x == blk.length_domain.last())):
+                            calculate_variable_from_constraint(
+                                solid_emulsion_rxn_gen[t, x, 'Sol', j],
+                                solid_emulsion_stoichiometry_eqn[t, x,
+                                                                 'Sol', j])
 
             blk.solid_emulsion_rxn_ext_constraint.activate()
             blk.gas_emulsion_hetero_rxn_eqn.activate()

--- a/idaes/gas_solid_contactors/unit_models/moving_bed.py
+++ b/idaes/gas_solid_contactors/unit_models/moving_bed.py
@@ -1026,9 +1026,14 @@ see reaction package for documentation.}"""))
                     for p in solid_phase.property_package.phase_list:
                         for j in solid_phase.property_package.component_list:
                             (solid_rxn_gen[t, x, p, j].unfix())
-                            calculate_variable_from_constraint(
-                                solid_rxn_gen[t, x, p, j],
-                                solid_phase_stoichiometry_eqn[t, x, p, j])
+                            if not (
+                                (blk.config.transformation_scheme != "FORWARD"
+                                 and x == blk.length_domain.first()) or
+                                (blk.config.transformation_scheme == "FORWARD"
+                                 and x == blk.length_domain.last())):
+                                calculate_variable_from_constraint(
+                                    solid_rxn_gen[t, x, p, j],
+                                    solid_phase_stoichiometry_eqn[t, x, p, j])
 
             blk.gas_comp_hetero_rxn.activate()
             blk.solid_phase.rate_reaction_stoichiometry_constraint.activate()

--- a/idaes/gas_solid_contactors/unit_models/tests/test_BFB.py
+++ b/idaes/gas_solid_contactors/unit_models/tests/test_BFB.py
@@ -211,8 +211,8 @@ class TestIronOC(object):
                           Constraint)
 
         assert number_variables(iron_oc) == 1436
-        assert number_total_constraints(iron_oc) == 1395
-        assert number_unused_variables(iron_oc) == 15
+        assert number_total_constraints(iron_oc) == 1392
+        assert number_unused_variables(iron_oc) == 18
 
     @pytest.mark.unit
     def test_dof(self, iron_oc):
@@ -418,8 +418,8 @@ class TestIronOC_EnergyBalanceType(object):
         assert isinstance(iron_oc.fs.unit.isothermal_bubble, Constraint)
 
         assert number_variables(iron_oc) == 1156
-        assert number_total_constraints(iron_oc) == 1052
-        assert number_unused_variables(iron_oc) == 79
+        assert number_total_constraints(iron_oc) == 1049
+        assert number_unused_variables(iron_oc) == 82
         print(unused_variables_set(iron_oc))
 
     @pytest.mark.unit

--- a/idaes/gas_solid_contactors/unit_models/tests/test_MB.py
+++ b/idaes/gas_solid_contactors/unit_models/tests/test_MB.py
@@ -204,8 +204,8 @@ class TestIronOC(object):
         assert isinstance(iron_oc.fs.unit.gas_comp_hetero_rxn, Constraint)
 
         assert number_variables(iron_oc) == 809
-        assert number_total_constraints(iron_oc) == 775
-        assert number_unused_variables(iron_oc) == 12
+        assert number_total_constraints(iron_oc) == 772
+        assert number_unused_variables(iron_oc) == 15
 
     @pytest.mark.unit
     def test_dof(self, iron_oc):
@@ -398,8 +398,8 @@ class TestIronOC_EnergyBalanceType(object):
         assert isinstance(iron_oc.fs.unit.isothermal_solid_phase, Constraint)
 
         assert number_variables(iron_oc) == 589
-        assert number_total_constraints(iron_oc) == 513
-        assert number_unused_variables(iron_oc) == 55
+        assert number_total_constraints(iron_oc) == 510
+        assert number_unused_variables(iron_oc) == 58
         print(unused_variables_set(iron_oc))
 
     @pytest.mark.unit


### PR DESCRIPTION
## Fixes



## Summary/Motivation:
Updates Moving Bed and Bubbling Fluidized Bed unit models to streamline them with changes made to CV1D in PR #230 

## Changes proposed in this PR:
- Logic was added to skip reaction stoichiometry constraints at the control volume boundaries

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
