### PR TITLE
Disable checks causing false positives with None-initialized variables

### DIFF
--- a/.pylint/pylintrc
+++ b/.pylint/pylintrc
@@ -7,6 +7,8 @@ ignore-patterns=test_.*
 disable=no-self-argument,
     bad-super-call,
     assignment-from-none,
+    invalid-unary-operand-type,
+    unsubscriptable-object,    
 
 [IMPORTS]
 ignored-modules=cvalsim,almsim
@@ -18,3 +20,4 @@ ignored-modules=cvalsim,almsim
 # (see e.g. https://github.com/PyCQA/pylint/issues/2498)
 # here "cm" refers to matplotlib.cm
 generated-members=cm\..*,
+ignore-none=yes


### PR DESCRIPTION
- This should address the pylint false positive errors due to pylint's inability to analyze conditionals, instead assuming that values initialized to `None` are permanently set to `None`
- There are two remaining errors but they seem to be caused by something else, namely a nonexisting `warn` member in `idaes.logger` 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
