### PR TITLE
Process output of DataFrame.to_string() to trim extra spaces on 3.6

### DIFF
--- a/idaes/surrogate/alamopy.py
+++ b/idaes/surrogate/alamopy.py
@@ -665,25 +665,41 @@ class AlamoTrainer(SurrogateTrainer):
         if trace_fname is not None:
             stream.write(f"TRACEFNAME {trace_fname}\n")
 
+        def _trim_extra_whitespace(text, sep=' '):
+            trimmed_lines = []
+            for line in text.splitlines():
+                parts = [part.strip() for part in line.split()]
+                trimmed_lines.append(str.join(sep, parts))
+            return str.join('\n', trimmed_lines)
+
+        def _df_to_data_fragment(df, **kwargs):
+            text = df.to_string(
+                header=False,
+                index=False,
+                float_format=lambda x: str(x).format(":g"),
+                **kwargs
+            )
+            # this is only needed to remove the extra spaces (from `justify`?) on python 3.6
+            # since on 3.7 and up pandas.to_string() returns already the proper format without any further string processing needed
+            return _trim_extra_whitespace(text, sep=' ')
+
         stream.write("\nBEGIN_DATA\n")
         # Columns will be writen in order in input and output lists
-        training_data.to_string(
-            buf=stream,
+        training_data_str = _df_to_data_fragment(
+            training_data,
             columns=self._input_labels + self._output_labels,
-            header=False,
-            index=False,
-            float_format=lambda x: str(x).format(":g"))
+        )
+        stream.write(training_data_str)
         stream.write("\nEND_DATA\n")
 
         if validation_data is not None:
             # Add validation data defintion
             stream.write("\nBEGIN_VALDATA\n")
-            validation_data.to_string(
-                buf=stream,
+            val_data_str = _df_to_data_fragment(
+                validation_data,
                 columns=self._input_labels + self._output_labels,
-                header=False,
-                index=False,
-                float_format=lambda x: str(x).format(":g"))
+            )
+            stream.write(val_data_str)
             stream.write("\nEND_VALDATA\n")
 
         if self.config.custom_basis_functions is not None:


### PR DESCRIPTION
This removes the extra spaces produced on Python 3.6 by using `str.split()` and then `str.join()` on each line to force a single space between numbers. A bit ham-fisted but it's anyway covered by tests and could be OK considering that we want to remove Python 3.6 soon anyway.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
