### PR TITLE
Address pylint failures for IDAES/idaes-pse#759

### DIFF
--- a/.pylint/idaes_transform.py
+++ b/.pylint/idaes_transform.py
@@ -4,6 +4,7 @@ dynamically created through the `declare_process_block_class()` decorator.
 
 See #1159 for more information.
 """
+from dataclasses import dataclass
 import sys
 import functools
 import logging
@@ -11,6 +12,7 @@ import time
 import typing
 
 import astroid
+import pylint
 from astroid.builder import extract_node, parse
 
 
@@ -21,21 +23,53 @@ _logger = logging.getLogger('pylint.ideas_plugin')
 _display = _notify = lambda *a, **kw: None
 
 
-REFERENCE_PYLINT_VERSION = '2.8.3'
+def _suppress_inference_errors(max_inferred=500) -> None:
+    """
+    Increasing this number to suppress inference errors causing false-positives in e.g. pandas.read_csv().
+    The value 500 is a sufficiently high number but otherwise arbitrary.
+    See https://github.com/PyCQA/pylint/issues/4577 for more information.
+    """
+    astroid.context.InferenceContext.max_inferred = int(max_inferred)
 
 
-def _check_version_compatibility():
+_suppress_inference_errors()
 
-    from pylint import __version__
-    if __version__ != REFERENCE_PYLINT_VERSION:
-        cmd_to_install = f"pip install pylint=={REFERENCE_PYLINT_VERSION}"
-        msg = (
-            f"WARNING: this plugin's reference version is {REFERENCE_PYLINT_VERSION}, "
-            f"but the currently installed pylint version is {__version__}. "
-            "This is not necessarily a problem; "
-            f"however, in case of issues, try installing the reference version using {cmd_to_install}"
+
+@dataclass
+class VersionCompat:
+    distr_name: str
+    expected: str
+    actual: str
+
+    @property
+    def cmd_to_install(self) -> str:
+        return f"pip install {self.distr_name}=={self.expected}"
+
+
+def _check_version_compatibility() -> None:
+
+    to_check = [
+        VersionCompat(
+            distr_name="pylint",
+            expected="2.12.2",
+            actual=pylint.__version__,
+        ),
+        VersionCompat(
+            distr_name="astroid",
+            expected="2.9.3",
+            actual=astroid.__version__,
         )
-        print(msg, file=sys.stderr)
+    ]
+    
+    for v in to_check:
+        if v.actual != v.expected:
+            msg = (
+                f"WARNING: this plugin's reference version for {v.distr_name} is {v.expected}, "
+                f"but the currently installed version for is {v.actual}. "
+                "This is not necessarily a problem; "
+                f"however, in case of issues, try installing the reference version using {v.cmd_to_install}"
+            )
+            print(msg, file=sys.stderr)
 
 
 def has_declare_block_class_decorator(cls_node, decorator_name="declare_process_block_class"):

--- a/.pylint/pylintrc
+++ b/.pylint/pylintrc
@@ -2,6 +2,7 @@
 init-hook="import sys; sys.path.append('.pylint')"
 load-plugins=idaes_transform
 ignore-patterns=test_.*
+ignore-paths=^idaes/apps/.*$,
 
 [MESSAGES CONTROL]
 disable=no-self-argument,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,8 +16,9 @@ sphinx-argparse
 pytest
 coverage
 pytest-cov
-# @lbianchi-lbl: pinned pylint version after update to 2.9.1 broke previously passing checks
-pylint==2.8.3
+# @lbianchi-lbl: both pylint and astroid should be tightly pinned; see .pylint/idaes_transform.py for more info
+pylint==2.12.2
+astroid==2.9.3
 flake8
 
 ### other/misc


### PR DESCRIPTION
## Fixes

pylint failures in IDAES/idaes-pse#759

## Summary/Motivation:

- We want to exclude `idaes/apps` from pylint checks, but the pylint version we're currently using doesn't support that
- Updating the pylint version is possible (and comes with significantly better performance), however results in a few false positives:

```txt
dule idaes.generic_models.unit_models.column_models.tray_column
idaes/generic_models/unit_models/column_models/tray_column.py:326:19: E1101: Instance of 'int' has no 'vap_out' member (no-member)
idaes/generic_models/unit_models/column_models/tray_column.py:332:24: E1101: Instance of 'int' has no 'liq_in' member (no-member)
idaes/generic_models/unit_models/column_models/tray_column.py:517:8: E1101: Instance of 'int' has no 'properties_in_liq' member (no-member)
 Module idaes.power_generation.unit_models.helm.turbine_multistage
idaes/power_generation/unit_models/helm/turbine_multistage.py:462:32: E1101: Instance of 'int' has no 'inlet' member (no-member)
idaes/power_generation/unit_models/helm/turbine_multistage.py:467:32: E1101: Instance of 'int' has no 'inlet' member (no-member)
idaes/power_generation/unit_models/helm/turbine_multistage.py:475:32: E1101: Instance of 'int' has no 'inlet' member (no-member)
idaes/power_generation/unit_models/helm/turbine_multistage.py:480:32: E1101: Instance of 'int' has no 'inlet' member (no-member)
idaes/power_generation/unit_models/helm/turbine_multistage.py:490:62: E1101: Instance of 'int' has no 'inlet' member (no-member)
idaes/power_generation/unit_models/helm/turbine_multistage.py:494:58: E1101: Instance of 'int' has no 'inlet' member (no-member)

```

## Changes proposed in this PR:

- Update pylint versions in `requirements-dev.txt`
- Add exclusion patterns for `idaes/apps` in `.pylint/pylintrc`
- Enhance `idaes_transform.py` pylint plugin to get rid of false positives introduced by the new version

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
