### PR TITLE
Suggested changes to `build_port` method

### DIFF
--- a/idaes/core/base/property_base.py
+++ b/idaes/core/base/property_base.py
@@ -537,14 +537,14 @@ class StateBlock(ProcessBlock):
 
         # Get dict of Port members and names
         # Need to get a representative member of StateBlockDatas
-        member_list = self[index].define_port_members()
+        port_member_dict = self[index].define_port_members()
 
         # Create References for port members
-        for s in member_list:
-            if not member_list[s].is_indexed():
-                slicer = subset.component(member_list[s].local_name)
+        for s in port_member_dict:
+            if not port_member_dict[s].is_indexed():
+                slicer = subset.component(port_member_dict[s].local_name)
             else:
-                slicer = subset.component(member_list[s].local_name)[...]
+                slicer = subset.component(port_member_dict[s].local_name)[...]
 
             r = Reference(slicer)
             setattr(target_block, "_" + s + "_" + port_name + "_ref", r)

--- a/idaes/core/base/property_base.py
+++ b/idaes/core/base/property_base.py
@@ -505,7 +505,14 @@ class StateBlock(ProcessBlock):
 
         ostream.write("\n" + "=" * max_str_length + "\n")
 
-    def build_port(self, target_block, port_name, doc=None, subset=None):
+    def build_port(
+        self,
+        target_block,
+        port_name,
+        doc=None,
+        subset=None,
+        index=None,
+    ):
         """
         Constructs a Port based on this StateBlock attached to the target block.
 
@@ -521,6 +528,8 @@ class StateBlock(ProcessBlock):
         """
         if subset is None:
             subset = self[...]
+        if index is None:
+            index = self.index_set().first()
 
         # Create empty Port
         p = Port(doc=doc)
@@ -528,8 +537,7 @@ class StateBlock(ProcessBlock):
 
         # Get dict of Port members and names
         # Need to get a representative member of StateBlockDatas
-        i0 = self.index_set().first()
-        member_list = self[i0].define_port_members()
+        member_list = self[index].define_port_members()
 
         # Create References for port members
         for s in member_list:

--- a/idaes/core/base/property_base.py
+++ b/idaes/core/base/property_base.py
@@ -510,7 +510,7 @@ class StateBlock(ProcessBlock):
         target_block,
         port_name,
         doc=None,
-        subset=None,
+        slice_index=None,
         index=None,
     ):
         """
@@ -520,14 +520,14 @@ class StateBlock(ProcessBlock):
             target_block - block to which Port should be attached
             port_name - name to use for Port
             doc - doc string or Prot object
-            subset - slicer representing a subset of indices of StateBlock which
-                should be included in Port
+            slice_index - Slice index (e.g. (slice(None), 0.0) that will be
+                used to index self when constructing port references.
 
         Returns:
             Port object
         """
-        if subset is None:
-            subset = self[...]
+        if slice_index is None:
+            slice_index = Ellipsis
         if index is None:
             index = self.index_set().first()
 
@@ -542,9 +542,13 @@ class StateBlock(ProcessBlock):
         # Create References for port members
         for s in port_member_dict:
             if not port_member_dict[s].is_indexed():
-                slicer = subset.component(port_member_dict[s].local_name)
+                slicer = self[slice_index].component(
+                    port_member_dict[s].local_name
+                )
             else:
-                slicer = subset.component(port_member_dict[s].local_name)[...]
+                slicer = self[slice_index].component(
+                    port_member_dict[s].local_name
+                )[...]
 
             r = Reference(slicer)
             setattr(target_block, "_" + s + "_" + port_name + "_ref", r)

--- a/idaes/core/base/tests/test_property_base.py
+++ b/idaes/core/base/tests/test_property_base.py
@@ -548,7 +548,7 @@ def test_StateBlock_build_port_2index_subset():
 
     # Build the Port
     m.state_block.build_port(
-        m.test_block, "test_port", "test_doc", subset=m.state_block[:, 10]
+        m.test_block, "test_port", "test_doc", slice_index=(slice(None), 10)
     )
 
     # Check References were constructed on test block

--- a/idaes/core/base/unit_model.py
+++ b/idaes/core/base/unit_model.py
@@ -244,7 +244,9 @@ Must be True if dynamic = True,
                     elif block._flow_direction == FlowDirection.backward:
                         _idx = block.length_domain.last()
 
-                    p = sblock.build_port(self, name, doc, subset=sblock[:, _idx])
+                    p = sblock.build_port(
+                        self, name, doc, slice_index=(slice(None), _idx)
+                    )
 
                 except AttributeError:
                     raise ConfigurationError(
@@ -329,7 +331,9 @@ Must be True if dynamic = True,
                     elif block._flow_direction == FlowDirection.forward:
                         _idx = block.length_domain.last()
 
-                    p = sblock.build_port(self, name, doc, subset=sblock[:, _idx])
+                    p = sblock.build_port(
+                        self, name, doc, slice_index=(slice(None), _idx)
+                    )
 
                 except AttributeError:
                     raise ConfigurationError(


### PR DESCRIPTION
## Summary/Motivation:
My suggested changes to PR https://github.com/IDAES/idaes-pse/pull/876 except for the API that avoids embedded `setattr`s.
- Avoid using a hard-coded index
- Use the variable name `port_member_dict` rather than `member_list`
- Specify the "subset of indices" with an index (e.g. `(slice(None), 0.0)` rather than a slice itself
- Add a method to get the standard name of a "port reference"

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
