### PR TITLE
Split functions to separate construction and addition-to-model of ports and their references

### DIFF
--- a/idaes/core/base/tests/test_property_base.py
+++ b/idaes/core/base/tests/test_property_base.py
@@ -447,7 +447,7 @@ def test_StateBlock_build_port_1index():
     m.test_block = Block()
 
     # Build the Port
-    m.state_block.build_port(m.test_block, "test_port", "test_doc")
+    m.state_block.build_port_and_add(m.test_block, "test_port", "test_doc")
 
     # Check References were constructed on test block
     assert isinstance(m.test_block._ScalarVar_test_port_ref, Var)
@@ -496,7 +496,7 @@ def test_StateBlock_build_port_2index():
     m.test_block = Block()
 
     # Build the Port
-    m.state_block.build_port(m.test_block, "test_port", "test_doc")
+    m.state_block.build_port_and_add(m.test_block, "test_port", "test_doc")
 
     # Check References were constructed on test block
     assert isinstance(m.test_block._ScalarVar_test_port_ref, Var)
@@ -547,7 +547,7 @@ def test_StateBlock_build_port_2index_subset():
     m.test_block = Block()
 
     # Build the Port
-    m.state_block.build_port(
+    m.state_block.build_port_and_add(
         m.test_block, "test_port", "test_doc", slice_index=(slice(None), 10)
     )
 

--- a/idaes/core/base/tests/test_unit_model.py
+++ b/idaes/core/base/tests/test_unit_model.py
@@ -195,7 +195,8 @@ def test_add_port_invalid_block():
     with pytest.raises(
         ConfigurationError,
         match="fs.u block object provided to add_port method is not an "
-        "instance of a StateBlock object \(does not have a build_port method\).",
+        "instance of a StateBlock object \(does not have a "
+        "build_port_and_add method\).",
     ):
         m.fs.u.add_port(name="test_port", block=m.fs.u)
 

--- a/idaes/core/base/unit_model.py
+++ b/idaes/core/base/unit_model.py
@@ -166,11 +166,13 @@ Must be True if dynamic = True,
         """
         # Create Port
         try:
-            p = block.build_port(self, name, doc)
+            # FIXME: What if name is None here? We probably need a default.
+            p = block.build_port_and_add(self, name, doc)
         except AttributeError:
             raise ConfigurationError(
                 f"{self.name} block object provided to add_port method is not an "
-                f"instance of a StateBlock object (does not have a build_port method)."
+                f"instance of a StateBlock object (does not have a "
+                f"build_port_and_add method)."
             )
 
         return p
@@ -232,7 +234,7 @@ Must be True if dynamic = True,
             # Work out if this is a 0D or 1D block
             try:
                 # Try 0D first
-                p = block.properties_in.build_port(self, name, doc)
+                p = block.properties_in.build_port_and_add(self, name, doc)
             except AttributeError:
                 # Otherwise a 1D control volume
                 try:
@@ -244,7 +246,7 @@ Must be True if dynamic = True,
                     elif block._flow_direction == FlowDirection.backward:
                         _idx = block.length_domain.last()
 
-                    p = sblock.build_port(
+                    p = sblock.build_port_and_add(
                         self, name, doc, slice_index=(slice(None), _idx)
                     )
 
@@ -256,7 +258,7 @@ Must be True if dynamic = True,
                     )
         else:
             # Assume a StateBlock indexed only by time
-            p = block.build_port(self, name, doc)
+            p = block.build_port_and_add(self, name, doc)
 
         return p
 
@@ -319,7 +321,7 @@ Must be True if dynamic = True,
             # Work out if this is a 0D or 1D block
             try:
                 # Try 0D first
-                p = block.properties_out.build_port(self, name, doc)
+                p = block.properties_out.build_port_and_add(self, name, doc)
             except AttributeError:
                 # Otherwise a 1D control volume
                 try:
@@ -331,7 +333,7 @@ Must be True if dynamic = True,
                     elif block._flow_direction == FlowDirection.forward:
                         _idx = block.length_domain.last()
 
-                    p = sblock.build_port(
+                    p = sblock.build_port_and_add(
                         self, name, doc, slice_index=(slice(None), _idx)
                     )
 
@@ -343,7 +345,7 @@ Must be True if dynamic = True,
                     )
         else:
             # Assume a StateBlock indexed only by time
-            p = block.build_port(self, name, doc)
+            p = block.build_port_and_add(self, name, doc)
 
         return p
 


### PR DESCRIPTION
## Changes proposed in this PR:
- Split `build_port` into two methods: `build_port_and_references` and `build_port_and_add`. `build_port_and_add` calls the former then adds the port and references. It has the same call signature as the former `build_port`
- Update **unit_model.py** to use `build_port_and_add` instead of the now nonexistant `build_port`

This is just my first simple solution to having some separation between construction and addition of ports (and their references), and not necessarily a prerequisite for merging https://github.com/IDAES/idaes-pse/pull/876

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
