### PR TITLE
Use a relative tolerance when checking parallel rows/cols

### DIFF
--- a/idaes/core/util/tests/test_model_diagnostics.py
+++ b/idaes/core/util/tests/test_model_diagnostics.py
@@ -975,7 +975,9 @@ The following pairs of constraints are nearly parallel:
         expected = """====================================================================================
 The following pairs of variables are nearly parallel:
 
+    v1, v2
     v1, v4
+    v2, v4
 
 ====================================================================================
 """
@@ -3075,7 +3077,9 @@ class TestCheckParallelJacobian:
     @pytest.mark.unit
     def test_columns(self, model):
         assert check_parallel_jacobian(model, direction="column") == [
-            (model.v1, model.v4)
+            (model.v1, model.v2),
+            (model.v1, model.v4),
+            (model.v2, model.v4),
         ]
 
 


### PR DESCRIPTION
- Relative tolerance for parallel comparison
- Update code to use more descriptive names
- Update tests. We identify more parallel variables in the test model when using a relative tolerance.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
